### PR TITLE
Add migration scripts and format user profile migration file 

### DIFF
--- a/server/migrations/20250116180003_userProfile.ts
+++ b/server/migrations/20250116180003_userProfile.ts
@@ -1,16 +1,21 @@
-import type { Knex } from "knex";
-
+import type { Knex } from 'knex';
 
 export async function up(knex: Knex): Promise<void> {
-    return knex.schema.withSchema('public').createTable('user_profile', (table) => {
-        table.integer('user_id').references('id').inTable('users').primary().onDelete('CASCADE');
-        table.string('name')
-        table.string('profile_picture');
-        table.string('bio');
+  return knex.schema
+    .withSchema('public')
+    .createTable('user_profile', (table) => {
+      table
+        .integer('user_id')
+        .references('id')
+        .inTable('users')
+        .primary()
+        .onDelete('CASCADE');
+      table.string('name');
+      table.string('profile_picture');
+      table.string('bio');
     });
 }
 
-
 export async function down(knex: Knex): Promise<void> {
-    return knex.schema.withSchema('public').dropTable('user_profile');
+  return knex.schema.withSchema('public').dropTable('user_profile');
 }

--- a/server/package.json
+++ b/server/package.json
@@ -5,7 +5,9 @@
   "scripts": {
     "start": "ts-node src/index.ts",
     "dev": "nodemon src/index.ts",
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "migrate:latest": "knex migrate:latest",
+    "migrate:reset": "knex migrate:rollback --all"
   },
   "keywords": [],
   "author": "",


### PR DESCRIPTION
- Formatei o arquivo de user_profile, coisas simples (aspas simples, quebras de linhas)
- Adicionei 2 scripts que podem ser executados agora com o `npm run` ao invés de instalar o Knex globalmente antes de rodá-los 